### PR TITLE
Add reusable footer with placeholder links

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,13 @@
+<footer class="bg-white dark:bg-neutral-800 border-t border-gray-200 dark:border-neutral-700 mt-12">
+    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 text-center text-gray-500 dark:text-gray-400 text-sm flex flex-col sm:flex-row items-center justify-between gap-2">
+        <div>
+            &copy; {{ date('Y') }} {{ config('app.name', 'Travel Together') }}. {{ __('All rights reserved.') }}
+        </div>
+        <nav class="space-x-4">
+            <a href="#" class="hover:underline">Imprint</a>
+            <a href="#" class="hover:underline">Privacy Policy</a>
+            <a href="#" class="hover:underline">Terms &amp; Conditions</a>
+            <a href="#" class="hover:underline">Cookies</a>
+        </nav>
+    </div>
+</footer>

--- a/resources/views/components/layouts/admin/header.blade.php
+++ b/resources/views/components/layouts/admin/header.blade.php
@@ -176,6 +176,8 @@
     </div>
 
 
+    <x-footer />
+
     @fluxScripts
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </body>

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -210,7 +210,9 @@
         {{ $slot }}
     </div>
 
-    @fluxScripts    
+    <x-footer />
+
+    @fluxScripts
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 
     

--- a/resources/views/components/layouts/auth/card.blade.php
+++ b/resources/views/components/layouts/auth/card.blade.php
@@ -21,6 +21,8 @@
                 </div>
             </div>
         </div>
+        <x-footer />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -17,6 +17,8 @@
                 </div>
             </div>
         </div>
+        <x-footer />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -38,6 +38,8 @@
                 </div>
             </div>
         </div>
+        <x-footer />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/frontend/homepage.blade.php
+++ b/resources/views/frontend/homepage.blade.php
@@ -390,12 +390,7 @@
         </main>
 
         {{-- Optional Footer --}}
-        <footer class="bg-white dark:bg-neutral-800 border-t border-gray-200 dark:border-neutral-700 mt-12">
-            <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 text-center text-gray-500 dark:text-gray-400 text-sm">
-                &copy; {{ date('Y') }} {{ config('app.name', 'Travel Together') }}. {{ __('All rights reserved.') }}
-                {{-- Add other footer links if needed: Privacy Policy, Terms, etc. --}}
-            </div>
-        </footer>
+        <x-footer />
 
     </div> {{-- End min-h-screen --}}
 </body>


### PR DESCRIPTION
## Summary
- create a `x-footer` blade component with placeholder links
- include the new footer in public, logged in, and admin layouts
- use the component on the homepage

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b2b12a88320bce6139f10473783