### PR TITLE
Add placeholder footer pages

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,13 @@
+<footer class="bg-white dark:bg-neutral-800 border-t border-gray-200 dark:border-neutral-700 mt-12">
+    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 text-center text-gray-500 dark:text-gray-400 text-sm flex flex-col sm:flex-row items-center justify-between gap-2">
+        <div>
+            &copy; {{ date('Y') }} {{ config('app.name', 'Travel Together') }}. {{ __('All rights reserved.') }}
+        </div>
+        <nav class="space-x-4">
+            <a href="{{ route('imprint') }}" class="hover:underline">Imprint</a>
+            <a href="{{ route('privacy') }}" class="hover:underline">Privacy Policy</a>
+            <a href="{{ route('terms') }}" class="hover:underline">Terms &amp; Conditions</a>
+            <a href="{{ route('cookies') }}" class="hover:underline">Cookies</a>
+        </nav>
+    </div>
+</footer>

--- a/resources/views/components/layouts/admin/header.blade.php
+++ b/resources/views/components/layouts/admin/header.blade.php
@@ -176,6 +176,8 @@
     </div>
 
 
+    <x-footer />
+
     @fluxScripts
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </body>

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -210,7 +210,9 @@
         {{ $slot }}
     </div>
 
-    @fluxScripts    
+    <x-footer />
+
+    @fluxScripts
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 
     

--- a/resources/views/components/layouts/auth/card.blade.php
+++ b/resources/views/components/layouts/auth/card.blade.php
@@ -21,6 +21,8 @@
                 </div>
             </div>
         </div>
+        <x-footer />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -17,6 +17,8 @@
                 </div>
             </div>
         </div>
+        <x-footer />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -38,6 +38,8 @@
                 </div>
             </div>
         </div>
+        <x-footer />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/frontend/cookies.blade.php
+++ b/resources/views/frontend/cookies.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    @include('partials.head')
+</head>
+<body class="antialiased bg-gray-100 dark:bg-neutral-900">
+    <header class="bg-white dark:bg-neutral-800 shadow">
+        <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <h1 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('Cookies') }}
+            </h1>
+        </div>
+    </header>
+    <main>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-neutral-800 shadow sm:rounded-lg p-6">
+                <p class="text-lg text-gray-600 dark:text-gray-400">Placeholder for future Cookie Policy details.</p>
+            </div>
+        </div>
+    </main>
+    <x-footer />
+</body>
+</html>

--- a/resources/views/frontend/homepage.blade.php
+++ b/resources/views/frontend/homepage.blade.php
@@ -390,12 +390,7 @@
         </main>
 
         {{-- Optional Footer --}}
-        <footer class="bg-white dark:bg-neutral-800 border-t border-gray-200 dark:border-neutral-700 mt-12">
-            <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 text-center text-gray-500 dark:text-gray-400 text-sm">
-                &copy; {{ date('Y') }} {{ config('app.name', 'Travel Together') }}. {{ __('All rights reserved.') }}
-                {{-- Add other footer links if needed: Privacy Policy, Terms, etc. --}}
-            </div>
-        </footer>
+        <x-footer />
 
     </div> {{-- End min-h-screen --}}
 </body>

--- a/resources/views/frontend/imprint.blade.php
+++ b/resources/views/frontend/imprint.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    @include('partials.head')
+</head>
+<body class="antialiased bg-gray-100 dark:bg-neutral-900">
+    <header class="bg-white dark:bg-neutral-800 shadow">
+        <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <h1 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('Imprint') }}
+            </h1>
+        </div>
+    </header>
+    <main>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-neutral-800 shadow sm:rounded-lg p-6">
+                <p class="text-lg text-gray-600 dark:text-gray-400">Placeholder for future Imprint details.</p>
+            </div>
+        </div>
+    </main>
+    <x-footer />
+</body>
+</html>

--- a/resources/views/frontend/privacy.blade.php
+++ b/resources/views/frontend/privacy.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    @include('partials.head')
+</head>
+<body class="antialiased bg-gray-100 dark:bg-neutral-900">
+    <header class="bg-white dark:bg-neutral-800 shadow">
+        <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <h1 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('Privacy Policy') }}
+            </h1>
+        </div>
+    </header>
+    <main>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-neutral-800 shadow sm:rounded-lg p-6">
+                <p class="text-lg text-gray-600 dark:text-gray-400">Placeholder for future Privacy Policy details.</p>
+            </div>
+        </div>
+    </main>
+    <x-footer />
+</body>
+</html>

--- a/resources/views/frontend/terms.blade.php
+++ b/resources/views/frontend/terms.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    @include('partials.head')
+</head>
+<body class="antialiased bg-gray-100 dark:bg-neutral-900">
+    <header class="bg-white dark:bg-neutral-800 shadow">
+        <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <h1 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('Terms & Conditions') }}
+            </h1>
+        </div>
+    </header>
+    <main>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-neutral-800 shadow sm:rounded-lg p-6">
+                <p class="text-lg text-gray-600 dark:text-gray-400">Placeholder for future Terms & Conditions.</p>
+            </div>
+        </div>
+    </main>
+    <x-footer />
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,10 @@ use Livewire\Volt\Volt;
 
 // 📌 Public routes
 Route::get('/', fn() => view('frontend.homepage'))->name('home');
+Route::view('/imprint', 'frontend.imprint')->name('imprint');
+Route::view('/privacy', 'frontend.privacy')->name('privacy');
+Route::view('/terms', 'frontend.terms')->name('terms');
+Route::view('/cookies', 'frontend.cookies')->name('cookies');
 
 Route::post('/set-locale', function () {
     $locale = request('locale');


### PR DESCRIPTION
## Summary
- add Imprint, Privacy Policy, Terms & Conditions and Cookie Policy pages
- link the footer items to the new routes
- register the new pages in `web.php`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b2b12a88320bce6139f10473783