### PR TITLE
Implement cookie banner

### DIFF
--- a/resources/views/components/cookie-banner.blade.php
+++ b/resources/views/components/cookie-banner.blade.php
@@ -1,0 +1,30 @@
+@if (!request()->cookie('cookie_consent'))
+<div id="cookie-banner" class="fixed bottom-0 inset-x-0 bg-gray-800 text-white p-4 hidden z-50">
+    <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm">
+        <span>
+            {{ __('This site uses cookies to improve your experience. By using our site, you agree to our') }}
+            <a href="{{ route('cookies') }}" class="underline">{{ __('Cookie Policy') }}</a>.
+        </span>
+        <button id="cookie-accept" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded">
+            {{ __('Accept') }}
+        </button>
+    </div>
+</div>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const banner = document.getElementById('cookie-banner');
+        if (!document.cookie.split('; ').some(row => row.startsWith('cookie_consent='))) {
+            banner.classList.remove('hidden');
+        }
+        const accept = document.getElementById('cookie-accept');
+        if (accept) {
+            accept.addEventListener('click', function () {
+                const expires = new Date();
+                expires.setFullYear(expires.getFullYear() + 1);
+                document.cookie = 'cookie_consent=1; expires=' + expires.toUTCString() + '; path=/';
+                banner.remove();
+            });
+        }
+    });
+</script>
+@endif

--- a/resources/views/components/layouts/admin/header.blade.php
+++ b/resources/views/components/layouts/admin/header.blade.php
@@ -178,6 +178,8 @@
 
     <x-footer />
 
+    <x-cookie-banner />
+
     @fluxScripts
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </body>

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -212,6 +212,8 @@
 
     <x-footer />
 
+    <x-cookie-banner />
+
     @fluxScripts
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 

--- a/resources/views/components/layouts/auth/card.blade.php
+++ b/resources/views/components/layouts/auth/card.blade.php
@@ -23,6 +23,8 @@
         </div>
         <x-footer />
 
+        <x-cookie-banner />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -19,6 +19,8 @@
         </div>
         <x-footer />
 
+        <x-cookie-banner />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -40,6 +40,8 @@
         </div>
         <x-footer />
 
+        <x-cookie-banner />
+
         @fluxScripts
     </body>
 </html>

--- a/resources/views/frontend/cookies.blade.php
+++ b/resources/views/frontend/cookies.blade.php
@@ -19,5 +19,6 @@
         </div>
     </main>
     <x-footer />
+    <x-cookie-banner />
 </body>
 </html>

--- a/resources/views/frontend/homepage.blade.php
+++ b/resources/views/frontend/homepage.blade.php
@@ -391,6 +391,7 @@
 
         {{-- Optional Footer --}}
         <x-footer />
+        <x-cookie-banner />
 
     </div> {{-- End min-h-screen --}}
 </body>

--- a/resources/views/frontend/imprint.blade.php
+++ b/resources/views/frontend/imprint.blade.php
@@ -19,5 +19,6 @@
         </div>
     </main>
     <x-footer />
+    <x-cookie-banner />
 </body>
 </html>

--- a/resources/views/frontend/privacy.blade.php
+++ b/resources/views/frontend/privacy.blade.php
@@ -19,5 +19,6 @@
         </div>
     </main>
     <x-footer />
+    <x-cookie-banner />
 </body>
 </html>

--- a/resources/views/frontend/terms.blade.php
+++ b/resources/views/frontend/terms.blade.php
@@ -19,5 +19,6 @@
         </div>
     </main>
     <x-footer />
+    <x-cookie-banner />
 </body>
 </html>

--- a/resources/views/frontend/user-directory.blade.php
+++ b/resources/views/frontend/user-directory.blade.php
@@ -26,6 +26,8 @@
                 </div>
             </div>
         </main>
+        <x-footer />
+        <x-cookie-banner />
     </div>
 </body>
 


### PR DESCRIPTION
## Summary
- add cookie consent banner component
- include banner in app, admin, and auth layouts
- include banner on frontend pages

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840936ed4448320b86b3bf43895571c