### PR TITLE
Implement bug report submission

### DIFF
--- a/app/Livewire/Admin/BugReports/Index.php
+++ b/app/Livewire/Admin/BugReports/Index.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Livewire\Admin\BugReports;
+
+use Livewire\Component;
+use App\Models\BugReport;
+use App\Notifications\BugReportReviewed;
+use Livewire\Attributes\{layout, middleware, title};
+use Illuminate\Support\Facades\Notification;
+
+#[Layout('components.layouts.admin.header')]
+#[Title('Admin - Bug Reports')]
+#[Middleware(['auth', 'admin_or_moderator'])]
+class Index extends Component
+{
+    public $reports;
+
+    public function mount()
+    {
+        $this->loadReports();
+    }
+
+    public function loadReports()
+    {
+        $this->reports = BugReport::where('status', 'pending')->latest()->get();
+    }
+
+    public function accept($id)
+    {
+        $report = BugReport::findOrFail($id);
+        $report->status = 'accepted';
+        $report->save();
+
+        $this->notifyReporter($report);
+        $this->loadReports();
+    }
+
+    public function reject($id)
+    {
+        $report = BugReport::findOrFail($id);
+        $report->status = 'rejected';
+        $report->save();
+
+        $this->notifyReporter($report);
+        $this->loadReports();
+    }
+
+    protected function notifyReporter(BugReport $report): void
+    {
+        if ($report->user) {
+            $report->user->notify(new BugReportReviewed($report->status));
+        } elseif ($report->email) {
+            Notification::route('mail', $report->email)->notify(new BugReportReviewed($report->status));
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.bug-reports.index');
+    }
+}

--- a/app/Livewire/BugReportForm.php
+++ b/app/Livewire/BugReportForm.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use App\Models\BugReport;
+
+class BugReportForm extends Component
+{
+    public ?string $email = null;
+    public string $message = '';
+    public string $url = '';
+
+    public function mount()
+    {
+        if (auth()->check()) {
+            $this->email = auth()->user()->email;
+        }
+        $this->url = request()->fullUrl();
+    }
+
+    public function submit()
+    {
+        $this->validate([
+            'email' => 'nullable|email',
+            'message' => 'required|string|max:1000',
+            'url' => 'nullable|string|max:255',
+        ]);
+
+        BugReport::create([
+            'user_id' => auth()->id(),
+            'email' => $this->email,
+            'message' => $this->message,
+            'url' => $this->url,
+            'status' => 'pending',
+        ]);
+
+        $this->reset('message');
+        session()->flash('success', __('Thanks for your feedback!'));
+    }
+
+    public function render()
+    {
+        return view('livewire.bug-report-form');
+    }
+}

--- a/app/Models/BugReport.php
+++ b/app/Models/BugReport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BugReport extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'email',
+        'message',
+        'url',
+        'status',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Notifications/BugReportReviewed.php
+++ b/app/Notifications/BugReportReviewed.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class BugReportReviewed extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $status)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        // Always send mail, add database channel for users
+        $channels = ['mail'];
+        if (method_exists($notifiable, 'getMorphClass')) {
+            $channels[] = 'database';
+        }
+        return $channels;
+    }
+
+    public function toMail($notifiable)
+    {
+        $statusText = ucfirst($this->status);
+
+        return (new MailMessage)
+            ->subject("Bug Report {$statusText}")
+            ->line('Thank you for your bug report.')
+            ->line("Your report was {$statusText}.")
+            ->action('Visit Site', url('/'));
+    }
+
+    public function toArray($notifiable)
+    {
+        return [
+            'title' => 'Bug Report '.ucfirst($this->status),
+            'body' => 'Your bug report was '.ucfirst($this->status).'.',
+            'url' => '/',
+        ];
+    }
+}

--- a/database/migrations/2025_06_01_000000_create_bug_reports_table.php
+++ b/database/migrations/2025_06_01_000000_create_bug_reports_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('bug_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('email')->nullable();
+            $table->text('message');
+            $table->string('url')->nullable();
+            $table->enum('status', ['pending', 'accepted', 'rejected'])->default('pending')->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('bug_reports');
+    }
+};

--- a/resources/views/components/admin/navbar.blade.php
+++ b/resources/views/components/admin/navbar.blade.php
@@ -57,6 +57,7 @@
         </flux:navbar.item>
         <flux:navmenu>
             <flux:navmenu.item :href="route('admin.reports')">{{ __('Reports') }}</flux:navmenu.item>
+            <flux:navmenu.item :href="route('admin.bug-reports')">{{ __('Bug Reports') }}</flux:navmenu.item>
         </flux:navmenu>
     </flux:dropdown>
 

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -17,5 +17,8 @@
                 {{__('Cookies')}}
             </a>
         </nav>
+        <div class="w-full sm:w-auto">
+            <livewire:bug-report-form />
+        </div>
     </div>
 </footer>

--- a/resources/views/livewire/admin/bug-reports/index.blade.php
+++ b/resources/views/livewire/admin/bug-reports/index.blade.php
@@ -1,0 +1,21 @@
+<div class="max-w-6xl mx-auto py-10 px-4">
+    <h1 class="text-3xl font-bold mb-6">{{ __('Bug Reports') }}</h1>
+
+    @if ($reports->isEmpty())
+        <p class="text-gray-600">{{ __('No pending bug reports.') }}</p>
+    @else
+        <div class="space-y-6">
+            @foreach ($reports as $report)
+                <div class="bg-white shadow rounded border p-4">
+                    <p class="mb-2 text-sm text-gray-500">{{ $report->created_at->diffForHumans() }} - {{ $report->url }}</p>
+                    <p class="mb-2">{{ $report->message }}</p>
+                    <p class="mb-4 text-sm text-gray-600">{{ $report->email }}</p>
+                    <div class="flex gap-2">
+                        <button wire:click="accept({{ $report->id }})" class="bg-green-600 hover:bg-green-700 text-white px-4 py-1 rounded">{{ __('Accept') }}</button>
+                        <button wire:click="reject({{ $report->id }})" class="bg-red-600 hover:bg-red-700 text-white px-4 py-1 rounded">{{ __('Reject') }}</button>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/bug-report-form.blade.php
+++ b/resources/views/livewire/bug-report-form.blade.php
@@ -1,0 +1,20 @@
+<div class="mt-6">
+    <form wire:submit.prevent="submit" class="space-y-2 text-left">
+        <div>
+            <label for="bug_email" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
+            <input type="email" id="bug_email" wire:model="email" class="mt-1 block w-full rounded-md border-gray-300 dark:bg-neutral-700 dark:border-neutral-600 dark:text-gray-300" />
+        </div>
+        <div>
+            <label for="bug_message" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Message</label>
+            <textarea id="bug_message" rows="3" wire:model="message" class="mt-1 block w-full rounded-md border-gray-300 dark:bg-neutral-700 dark:border-neutral-600 dark:text-gray-300"></textarea>
+            @error('message') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
+        </div>
+        <input type="hidden" wire:model="url" />
+        <div class="text-right">
+            <flux:button type="submit" variant="primary" wire:loading.attr="disabled">
+                <span wire:loading wire:target="submit" class="mr-1"><flux:icon.loading /></span>
+                {{ __('Send') }}
+            </flux:button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/pages/admin/bug-reports/index.blade.php
+++ b/resources/views/livewire/pages/admin/bug-reports/index.blade.php
@@ -1,0 +1,15 @@
+<?php
+use Livewire\Volt\Component;
+use Livewire\Attributes\{layout, middleware, title};
+
+new
+#[Layout('components.layouts.admin.header')]
+#[Title('Admin - Bug Reports')]
+#[Middleware(['auth', 'admin_or_moderator'])]
+class extends Component {}
+?>
+
+<div>
+    <h1 class="text-2xl font-semibold mb-6">{{ __('Bug Reports') }}</h1>
+    <livewire:admin.bug-reports.index />
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,7 +82,15 @@ Route::prefix('admin')
         Volt::route('/', 'pages.admin.dashboard')->name('dashboard');
 
         // Admin panels
-        foreach (['users' => 'users.index', 'posts' => 'posts.index', 'messages' => 'messages.index', 'hobbies' => 'hobbies.index', 'travel-styles' => 'travel-styles.index', 'reports' => 'reports.index',] as $path => $view) {
+        foreach ([
+            'users' => 'users.index',
+            'posts' => 'posts.index',
+            'messages' => 'messages.index',
+            'hobbies' => 'hobbies.index',
+            'travel-styles' => 'travel-styles.index',
+            'reports' => 'reports.index',
+            'bug-reports' => 'bug-reports.index',
+        ] as $path => $view) {
             Volt::route("/$path", "pages.admin.$view")->name($path);
         }
 


### PR DESCRIPTION
## Summary
- create `bug_reports` table migration with status column
- add BugReport model
- notify reporters when their bug report is reviewed
- create frontend bug report form and embed it in footer
- add admin interface to accept or reject bug reports
- register admin route and menu entry

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840999a09e883209ab950eccd35e70b